### PR TITLE
Allow HTTP status code 0

### DIFF
--- a/.github/workflows/check_links.yaml
+++ b/.github/workflows/check_links.yaml
@@ -32,9 +32,6 @@ jobs:
       #
       # If there is a valid external link that fails,
       # add it to mlc_config.json
-      - name: External links must be checked, do not allow '0' in the 'aliveStatusCodes' of mlc_config.json
-        run: if [[ $(grep --regexp "[^0-9]0[^0-9]" mlc_config.json | wc --lines) == "1" ]]; then echo "FOUND"; exit 42; fi
-
       - name: Internal links must checked, do not allow '400' in the 'aliveStatusCodes' of mlc_config.json
         run: if [[ $(grep --regexp "[^0-9]400[^0-9]" mlc_config.json | wc --lines) == "1" ]]; then echo "FOUND"; exit 42; fi
 

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,14 +1,3 @@
 {
-  "aliveStatusCodes": [200, 403, 418, 503],
-  "ignorePatterns": [
-    {
-      "pattern": "https://www.mygoblet.org"
-    },
-    {
-      "pattern" : "https://www.go-fair.org/resources/faq/ask-question-difference-fair-data-open-data/"
-    },
-    {
-      "pattern" : "https://www.dtls.nl"
-    }
-  ]
+  "aliveStatusCodes": [200, 403, 418, 503]
 }

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,3 +1,3 @@
 {
-  "aliveStatusCodes": [200, 403, 418, 503]
+  "aliveStatusCodes": [0, 200, 403, 418, 503]
 }


### PR DESCRIPTION
Hi @GeertvanGeest,

I've read at [#90](https://github.com/elixir-europe-training/ELIXIR-TrP-FAIR-training-handbook/pull/90#issuecomment-2624893992) from you:

> Had to add quite a few exceptions to mlc_config.json

Since a couple of days I've had the insight that it is better to allow HTTP status code 0 over whitelisting URLs, as the whitelisted URLs will break without notice (for example, in [the UPPMAX HPC center's documentation](https://github.com/UPPMAX/UPPMAX-documentation)).

With this pull request, I do the same for this repo. I think you'll be (even) happier with this setup :+1:

